### PR TITLE
feature(theme): Victoria Theme 

### DIFF
--- a/config/sync/admin_toolbar.settings.yml
+++ b/config/sync/admin_toolbar.settings.yml
@@ -1,0 +1,8 @@
+_core:
+  default_config_hash: uyQNqftluizBjDPnFYOJseLmtGK0tyiCkOyBmLkjOio
+enable_toggle_shortcut: false
+menu_depth: 4
+sticky_behavior: enabled
+hoverintent_behavior:
+  enabled: true
+  timeout: 500

--- a/config/sync/admin_toolbar_search.settings.yml
+++ b/config/sync/admin_toolbar_search.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: V3JovT-dwGbhWQNW7pu-TKg5B5toqYxDG8KfM26wNlI
+display_menu_item: false
+enable_keyboard_shortcut: true

--- a/config/sync/admin_toolbar_tools.settings.yml
+++ b/config/sync/admin_toolbar_tools.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: gw53MTkdqcnGCABUzyXtstgzZKWSpwznplfZdkdY8V0
+max_bundle_number: 20
+show_local_tasks: false

--- a/config/sync/block.block.gin_breadcrumbs.yml
+++ b/config/sync/block.block.gin_breadcrumbs.yml
@@ -1,0 +1,22 @@
+uuid: 89e50655-530b-4fa8-b0a3-301b11f02aee
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - gin
+_core:
+  default_config_hash: y9X3xgCsO59pQyzNLzY1D3SDJJxCHILLWkpPnmuTJ2E
+id: gin_breadcrumbs
+theme: gin
+region: breadcrumb
+weight: 0
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.gin_content.yml
+++ b/config/sync/block.block.gin_content.yml
@@ -1,0 +1,22 @@
+uuid: 09df06b5-de98-4055-9705-1072bb9f0121
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - gin
+_core:
+  default_config_hash: hBHXB7hC05XU7pDYzETt-GUcpFlogK1gkjyAsg0Ym58
+id: gin_content
+theme: gin
+region: content
+weight: 0
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.gin_help.yml
+++ b/config/sync/block.block.gin_help.yml
@@ -1,0 +1,22 @@
+uuid: 53f05f15-e77f-44ae-888e-453b4f94b87a
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - gin
+_core:
+  default_config_hash: 8nOAry2oKqJOr0zbrlJ3sZHDFJLIO6j-0vT0K_TYca4
+id: gin_help
+theme: gin
+region: help
+weight: 0
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  label_display: '0'
+  provider: help
+visibility: {  }

--- a/config/sync/block.block.gin_local_actions.yml
+++ b/config/sync/block.block.gin_local_actions.yml
@@ -1,0 +1,20 @@
+uuid: 95654eb3-97a9-415f-b0b2-3d942452bd19
+langcode: en
+status: true
+dependencies:
+  theme:
+    - gin
+_core:
+  default_config_hash: OQ9aJ-4qVwK1x00o9EOYK4eFDjQr_HLpbPiJaPSVZiQ
+id: gin_local_actions
+theme: gin
+region: content
+weight: -10
+provider: null
+plugin: local_actions_block
+settings:
+  id: local_actions_block
+  label: 'Primary admin actions'
+  label_display: '0'
+  provider: core
+visibility: {  }

--- a/config/sync/block.block.gin_messages.yml
+++ b/config/sync/block.block.gin_messages.yml
@@ -1,0 +1,22 @@
+uuid: 3d65f835-9451-449d-8813-c2778bf095dd
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - gin
+_core:
+  default_config_hash: WvPhI8OwllG0gE69-F8qL3ai3nd5SbYD6JpmEuZcyok
+id: gin_messages
+theme: gin
+region: highlighted
+weight: 0
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status messages'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.gin_page_title.yml
+++ b/config/sync/block.block.gin_page_title.yml
@@ -1,0 +1,20 @@
+uuid: 4ba5d109-cd7d-4439-9f97-f8c53cb550b4
+langcode: en
+status: true
+dependencies:
+  theme:
+    - gin
+_core:
+  default_config_hash: HLQY2xgby8K3vN_98hiOSasOhm9pdCsH234-s0duJ8Q
+id: gin_page_title
+theme: gin
+region: header
+weight: -30
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  label_display: '0'
+  provider: core
+visibility: {  }

--- a/config/sync/block.block.gin_primary_local_tasks.yml
+++ b/config/sync/block.block.gin_primary_local_tasks.yml
@@ -1,0 +1,22 @@
+uuid: 26c8826c-aca7-4475-bb48-e98608d63b9d
+langcode: en
+status: true
+dependencies:
+  theme:
+    - gin
+_core:
+  default_config_hash: Hh01DLj9k7UnNdPpOQXHZHW7GHf2OPNDQyCJF7_R9ac
+id: gin_primary_local_tasks
+theme: gin
+region: header
+weight: 0
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Primary tabs'
+  label_display: '0'
+  provider: core
+  primary: true
+  secondary: false
+visibility: {  }

--- a/config/sync/block.block.gin_secondary_local_tasks.yml
+++ b/config/sync/block.block.gin_secondary_local_tasks.yml
@@ -1,0 +1,22 @@
+uuid: e2121132-e1af-4c95-bd34-2eb0db31a433
+langcode: en
+status: true
+dependencies:
+  theme:
+    - gin
+_core:
+  default_config_hash: BCWhood0xXFQYqxFgL1spXdb9KeIuXH1YvTdjIEedDg
+id: gin_secondary_local_tasks
+theme: gin
+region: pre_content
+weight: 0
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Secondary tabs'
+  label_display: '0'
+  provider: core
+  primary: false
+  secondary: true
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_account_menu.yml
+++ b/config/sync/block.block.victoria_theme_account_menu.yml
@@ -1,0 +1,27 @@
+uuid: c43dfd82-c513-422b-848f-042bda5b831d
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.account
+  module:
+    - system
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: gmxYWWHmgbe0Pnv8y48ZLSLH5mEHejOjAP6RLxUfdzU
+id: victoria_theme_account_menu
+theme: victoria_theme
+region: secondary_menu
+weight: -4
+provider: null
+plugin: 'system_menu_block:account'
+settings:
+  id: 'system_menu_block:account'
+  label: 'User account menu'
+  label_display: '0'
+  provider: system
+  level: 1
+  depth: 1
+  expand_all_items: false
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_breadcrumbs.yml
+++ b/config/sync/block.block.victoria_theme_breadcrumbs.yml
@@ -1,0 +1,22 @@
+uuid: ceaf8134-dab4-4299-af69-33a2cb27222d
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: VhBzWb7lMRtIOg9G7VSw_0uopi-7zXeHq4vXqqV1HFE
+id: victoria_theme_breadcrumbs
+theme: victoria_theme
+region: content
+weight: -6
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_content.yml
+++ b/config/sync/block.block.victoria_theme_content.yml
@@ -1,0 +1,22 @@
+uuid: 2cfccf57-85f6-46ac-ab8c-72f6568a7432
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: erQSEZF2XUjNmgTl0uNRBzmg18ZGXwUcw2FhApoeuHk
+id: victoria_theme_content
+theme: victoria_theme
+region: content
+weight: -4
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_help.yml
+++ b/config/sync/block.block.victoria_theme_help.yml
@@ -1,0 +1,22 @@
+uuid: e362af09-de98-4ac7-aa5a-c6f6ed6444b3
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: VfPFqqxfkomud5CO8DUijw85QIl9GIxh_nIxLOYESxg
+id: victoria_theme_help
+theme: victoria_theme
+region: header
+weight: -4
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  label_display: '0'
+  provider: help
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_main_menu.yml
+++ b/config/sync/block.block.victoria_theme_main_menu.yml
@@ -1,0 +1,27 @@
+uuid: 8ac734ca-28a8-40cf-b67c-c4726274f7cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - system
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: KWAiziL39uEzmOJEql_wbUP2RtqGceL3WM2CfxhMelE
+id: victoria_theme_main_menu
+theme: victoria_theme
+region: primary_menu
+weight: 0
+provider: null
+plugin: 'system_menu_block:main'
+settings:
+  id: 'system_menu_block:main'
+  label: 'Main navigation'
+  label_display: '0'
+  provider: system
+  level: 1
+  depth: 2
+  expand_all_items: true
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_messages.yml
+++ b/config/sync/block.block.victoria_theme_messages.yml
@@ -1,0 +1,22 @@
+uuid: ccce6de9-5091-4288-a12b-2afedfc44897
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: BZ5tpW7H8X4PVGRm3MImTIHd2tN0eF7zOtp4SpRYUA0
+id: victoria_theme_messages
+theme: victoria_theme
+region: content
+weight: -5
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status messages'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_page_title.yml
+++ b/config/sync/block.block.victoria_theme_page_title.yml
@@ -1,0 +1,20 @@
+uuid: a83dd07c-2386-4f14-9a01-2826369670a6
+langcode: en
+status: true
+dependencies:
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: 6aOgWsNTXjqrDm98TXSAjP6qd2nCijD1xw45MrnbK-Y
+id: victoria_theme_page_title
+theme: victoria_theme
+region: content
+weight: -7
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  label_display: '0'
+  provider: core
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_powered.yml
+++ b/config/sync/block.block.victoria_theme_powered.yml
@@ -1,0 +1,22 @@
+uuid: 6d9bd68c-26f8-4089-8720-492a8bf96f81
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: eYL19CLDyinGTWYQfBD1DswWzglEotE_kHnHx3AxTXM
+id: victoria_theme_powered
+theme: victoria_theme
+region: footer
+weight: -7
+provider: null
+plugin: system_powered_by_block
+settings:
+  id: system_powered_by_block
+  label: 'Powered by Drupal'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_primary_admin_actions.yml
+++ b/config/sync/block.block.victoria_theme_primary_admin_actions.yml
@@ -1,0 +1,20 @@
+uuid: 0b2f83d2-cd4f-4efa-b0a9-6a39409bbbf1
+langcode: en
+status: true
+dependencies:
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: Q9_2whdOj1YIomfvsIfopROW4FT_X5pY0DjdOiOaQ5U
+id: victoria_theme_primary_admin_actions
+theme: victoria_theme
+region: header
+weight: -5
+provider: null
+plugin: local_actions_block
+settings:
+  id: local_actions_block
+  label: 'Primary admin actions'
+  label_display: '0'
+  provider: core
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_primary_local_tasks.yml
+++ b/config/sync/block.block.victoria_theme_primary_local_tasks.yml
@@ -1,0 +1,22 @@
+uuid: 8e621749-8b1b-4f18-9be8-7d08f85026e3
+langcode: en
+status: true
+dependencies:
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: nGE3EoPQQaQCuqTUtZgw0-KIzmrqdKDzdNQf2JyPUt4
+id: victoria_theme_primary_local_tasks
+theme: victoria_theme
+region: header
+weight: -7
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Primary tabs'
+  label_display: '0'
+  provider: core
+  primary: true
+  secondary: false
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_search_form_narrow.yml
+++ b/config/sync/block.block.victoria_theme_search_form_narrow.yml
@@ -1,0 +1,23 @@
+uuid: 61ced646-9d6e-477c-a6e4-85f2d2833b81
+langcode: en
+status: true
+dependencies:
+  module:
+    - search
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: _nZjxxdypO6xrOAJkCYD81v0L7wh2zbCAVO7_C-UKIc
+id: victoria_theme_search_form_narrow
+theme: victoria_theme
+region: primary_menu
+weight: -4
+provider: null
+plugin: search_form_block
+settings:
+  id: search_form_block
+  label: 'Search form (narrow)'
+  label_display: '0'
+  provider: search
+  page_id: null
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_search_form_wide.yml
+++ b/config/sync/block.block.victoria_theme_search_form_wide.yml
@@ -1,0 +1,23 @@
+uuid: 21205da3-cffc-4a18-b1ed-4d17d3ae5a20
+langcode: en
+status: true
+dependencies:
+  module:
+    - search
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: pbbed0hdqGDF-_QWVVTWRAwgDIotFuAvWH5mWUZu0fA
+id: victoria_theme_search_form_wide
+theme: victoria_theme
+region: secondary_menu
+weight: -5
+provider: null
+plugin: search_form_block
+settings:
+  id: search_form_block
+  label: 'Search form (wide)'
+  label_display: '0'
+  provider: search
+  page_id: null
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_secondary_local_tasks.yml
+++ b/config/sync/block.block.victoria_theme_secondary_local_tasks.yml
@@ -1,0 +1,22 @@
+uuid: 0a2f3a28-0016-4af1-913f-bde29eda5825
+langcode: en
+status: true
+dependencies:
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: ydSxdq7R66I8UMC460rOzlfzvlUL4VRbdwc6z9DWaUI
+id: victoria_theme_secondary_local_tasks
+theme: victoria_theme
+region: header
+weight: -6
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Secondary tabs'
+  label_display: '0'
+  provider: core
+  primary: false
+  secondary: true
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_site_branding.yml
+++ b/config/sync/block.block.victoria_theme_site_branding.yml
@@ -1,0 +1,25 @@
+uuid: 8e5c359b-d28d-4035-8d3b-d1951d0e1244
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - victoria_theme
+_core:
+  default_config_hash: '-OAAZDw1OR_UyAEPEKX0Hu4LaZD149vW9PmMnIC-v0o'
+id: victoria_theme_site_branding
+theme: victoria_theme
+region: header
+weight: -8
+provider: null
+plugin: system_branding_block
+settings:
+  id: system_branding_block
+  label: 'Site branding'
+  label_display: '0'
+  provider: system
+  use_site_logo: true
+  use_site_name: true
+  use_site_slogan: true
+visibility: {  }

--- a/config/sync/block.block.victoria_theme_views_block__projects_block_1_2.yml
+++ b/config/sync/block.block.victoria_theme_views_block__projects_block_1_2.yml
@@ -1,0 +1,29 @@
+uuid: 1c014176-dd62-4e73-a06b-1f21a3835630
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.projects
+  module:
+    - system
+    - views
+  theme:
+    - victoria_theme
+id: victoria_theme_views_block__projects_block_1_2
+theme: victoria_theme
+region: sidebar_second
+weight: -7
+provider: null
+plugin: 'views_block:projects-block_1'
+settings:
+  id: 'views_block:projects-block_1'
+  label: ''
+  label_display: visible
+  provider: views
+  views_label: ''
+  items_per_page: null
+visibility:
+  request_path:
+    id: request_path
+    negate: true
+    pages: "/projects\r\n/projects*\r\n<front>"

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -1,6 +1,9 @@
 _core:
   default_config_hash: 4GIX5Esnc_umpXUBj4IIocRX7Mt5fPhm4AgXfE3E56E
 module:
+  admin_toolbar: 0
+  admin_toolbar_search: 0
+  admin_toolbar_tools: 0
   announcements_feed: 0
   automated_cron: 0
   big_pipe: 0
@@ -20,6 +23,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  gin_toolbar: 0
   help: 0
   history: 0
   image: 0
@@ -50,4 +54,6 @@ module:
 theme:
   olivero: 0
   claro: 0
+  gin: 0
+  victoria_theme: 0
 profile: standard

--- a/config/sync/gin.settings.yml
+++ b/config/sync/gin.settings.yml
@@ -1,0 +1,26 @@
+_core:
+  default_config_hash: c8aZhkIY8zHUo0_UOll4vVs_l48dHL_gBqbvfuAM0Rs
+favicon:
+  use_default: true
+features:
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: true
+  node_user_picture: true
+logo:
+  use_default: true
+third_party_settings:
+  shortcut:
+    module_link: true
+preset_accent_color: pink
+preset_focus_color: gin
+enable_darkmode: '0'
+classic_toolbar: new
+secondary_toolbar_frontend: true
+high_contrast_mode: false
+accent_color: ''
+focus_color: ''
+layout_density: medium
+show_description_toggle: false
+show_user_theme_settings: false
+sticky_action_buttons: false

--- a/config/sync/system.theme.yml
+++ b/config/sync/system.theme.yml
@@ -1,4 +1,4 @@
 _core:
   default_config_hash: eJ529VM1gSIA_vgTy2PdiDvJuG0xhSxfQjCyl5WKlv4
-admin: claro
-default: olivero
+admin: gin
+default: victoria_theme


### PR DESCRIPTION
With Twig override and Latest Projects block
## What was done
- Created a custom theme **Victoria Theme** (based on Olivero), with CSS/JS libraries.
- Added Twig override `node--project--teaser.html.twig` to display title, image (`field_image2`) and body.
- Added custom styles in `style.css` (cards + grid) for the *Latest Projects* block.
- View configuration: Page display (`/projects`) and Block display (sidebar). Block is hidden on `/projects`.
- Rearranged core blocks (moved Page title and Status messages to Content; moved Powered by Drupal to Footer).
- Exported configuration with `drush cex`.

## How to test
1. Enable **Victoria Theme** as the default theme, keep **Gin** as the admin theme.
2. Visit `/projects` → shows the full list without the sidebar block.
3. Visit any `/node/...` page → the *Latest Projects* block appears in the sidebar as cards.
4. Open browser DevTools console → log `Victoria Theme: JS loaded` should appear.